### PR TITLE
feat: variable concurrent viewers

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "youtube-live",
 	"shortname": "YT",
 	"description": "Simple module for controlling YouTube live broadcasts",
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-youtube-live.git",
 	"bugs": "https://github.com/bitfocus/companion-module-youtube-live/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "youtube-live",
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"main": "dist/index.js",
 	"license": "MIT",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build:main": "tsc -p tsconfig.build.json",
 		"build:watch": "tsc -p tsconfig.build.json --watch",
 		"lint": "eslint . --ext .ts",
-		"test": "jest"
+		"test": "jest --runInBand"
 	},
 	"repository": {
 		"type": "git",

--- a/src/__tests__/actions.ts
+++ b/src/__tests__/actions.ts
@@ -34,6 +34,7 @@ const SampleMemory: StateMemory = {
 			BoundStreamId: 'abcd',
 			ScheduledStartTime: '2021-11-30T20:00:00',
 			LiveChatId: 'lcTest',
+			LiveConcurrentViewers: '33',
 		},
 	},
 	Streams: {},

--- a/src/__tests__/core.ts
+++ b/src/__tests__/core.ts
@@ -62,6 +62,7 @@ describe('Miscellaneous', () => {
 					BoundStreamId: 'sA',
 					ScheduledStartTime: '2020-11-30T08:08:00',
 					LiveChatId: 'lcA',
+					LiveConcurrentViewers: '0',
 				},
 			},
 			Streams: {
@@ -79,6 +80,7 @@ describe('Miscellaneous', () => {
 					BoundStreamId: 'sA',
 					ScheduledStartTime: '2020-11-30T08:08:00',
 					LiveChatId: 'lcA',
+					LiveConcurrentViewers: '0',
 				},
 			],
 		};
@@ -193,6 +195,7 @@ describe('Starting tests on broadcasts', () => {
 					BoundStreamId: 'sA',
 					ScheduledStartTime: '2021-11-30T22:00:00',
 					LiveChatId: 'lcA',
+					LiveConcurrentViewers: '0',
 				},
 			},
 			Streams: {
@@ -286,6 +289,7 @@ describe('Going live with broadcasts', () => {
 					BoundStreamId: 'sA',
 					ScheduledStartTime: '2021-11-30T20:00:00',
 					LiveChatId: 'lcA',
+					LiveConcurrentViewers: '0',
 				},
 			},
 			Streams: {
@@ -385,6 +389,7 @@ describe('Finishing live broadcasts', () => {
 					BoundStreamId: 'sA',
 					ScheduledStartTime: '2021-11-30T20:00:00',
 					LiveChatId: 'lcA',
+					LiveConcurrentViewers: '0',
 				},
 			},
 			Streams: {
@@ -447,6 +452,7 @@ describe('Toggling live broadcasts', () => {
 					BoundStreamId: 'sA',
 					ScheduledStartTime: '2021-11-30T20:00:00',
 					LiveChatId: 'lcA',
+					LiveConcurrentViewers: '0',
 				},
 			},
 			Streams: {

--- a/src/__tests__/feedbacks.ts
+++ b/src/__tests__/feedbacks.ts
@@ -29,6 +29,7 @@ const SampleMemory: StateMemory = {
 			BoundStreamId: 'abcd',
 			ScheduledStartTime: '2021-11-30T20:00:00',
 			LiveChatId: 'lcTest',
+			LiveConcurrentViewers: '24',
 		},
 	},
 	Streams: {
@@ -365,6 +366,7 @@ describe('Stream health feedback', () => {
 					BoundStreamId: 'abcd',
 					ScheduledStartTime: '2021-11-30T20:00:00',
 					LiveChatId: 'lcTest',
+					LiveConcurrentViewers: '24',
 				},
 			},
 			Streams: {},

--- a/src/__tests__/presets.ts
+++ b/src/__tests__/presets.ts
@@ -2,14 +2,14 @@
 import { listPresets } from '../presets';
 import { BroadcastMap, BroadcastLifecycle } from '../cache';
 
-describe('Preset presence', () => {
+describe('Preset list', () => {
 	test('There are no broadcast-independent presets', () => {
 		const broadcasts: BroadcastMap = {};
 		const result = listPresets(() => ({ broadcasts: broadcasts, unfinishedCount: 0 }));
 		expect(Object.keys(result).length).toBe(0);
 	});
 
-	test('Each broadcast adds four or more presets', () => {
+	test('Presets correctly generated for broadcast', () => {
 		const broadcasts: BroadcastMap = {
 			test: {
 				Id: 'test',
@@ -19,9 +19,41 @@ describe('Preset presence', () => {
 				MonitorStreamEnabled: true,
 				ScheduledStartTime: '2021-11-30T20:00:00',
 				LiveChatId: 'lcTest',
+				LiveConcurrentViewers: '0',
+			},
+		};
+		const result = listPresets(() => ({ broadcasts: broadcasts, unfinishedCount: 0 }))
+		expect(Object.keys(result).length).toEqual(4);
+		expect(result).toHaveProperty('start_broadcast_test');
+		expect(result).toHaveProperty('stop_broadcast_test');
+		expect(result).toHaveProperty('toggle_broadcast_test');
+		expect(result).toHaveProperty('init_broadcast_test');
+		expect(result).not.toHaveProperty('unfinished_state_name_0');
+		expect(result).not.toHaveProperty('unfinished_stream_health_0');
+		expect(result).not.toHaveProperty('unfinished_concurrent_viewers_number_0');
+	});
+
+	test('Presets correctly generated for unfinished broadcast', () => {
+		const broadcasts: BroadcastMap = {
+			test: {
+				Id: 'test',
+				Name: 'Sample Broadcast',
+				Status: BroadcastLifecycle.Ready,
+				BoundStreamId: 'abcd1234',
+				MonitorStreamEnabled: true,
+				ScheduledStartTime: '2021-11-30T20:00:00',
+				LiveChatId: 'lcTest',
+				LiveConcurrentViewers: '0',
 			},
 		};
 		const result = listPresets(() => ({ broadcasts: broadcasts, unfinishedCount: 1 }))
-		expect(Object.keys(result).length).toBeGreaterThanOrEqual(4);
+		expect(Object.keys(result).length).toEqual(7);
+		expect(result).toHaveProperty('start_broadcast_test');
+		expect(result).toHaveProperty('stop_broadcast_test');
+		expect(result).toHaveProperty('toggle_broadcast_test');
+		expect(result).toHaveProperty('init_broadcast_test');
+		expect(result).toHaveProperty('unfinished_state_name_0');
+		expect(result).toHaveProperty('unfinished_stream_health_0');
+		expect(result).toHaveProperty('unfinished_concurrent_viewers_number_0');
 	});
 });

--- a/src/__tests__/vars.ts
+++ b/src/__tests__/vars.ts
@@ -14,6 +14,7 @@ const SampleMemory: StateMemory = {
 			BoundStreamId: 'streamID',
 			ScheduledStartTime: '2021-11-30T20:00:00',
 			LiveChatId: 'livechatID',
+			LiveConcurrentViewers: '0',
 		},
 	},
 	Streams: {
@@ -43,7 +44,7 @@ describe('Variable declarations', () => {
 	});
 
 	test('Lifecycle and health added for each broadcast', () => {
-		const result = declareVars(SampleMemory, 1);
+		const result = declareVars(SampleMemory, 0);
 
 		expect(result).toEqual(
 			expect.arrayContaining([
@@ -57,6 +58,50 @@ describe('Variable declarations', () => {
 			expect.arrayContaining([
 				expect.objectContaining({
 					variableId: 'broadcast_broadcastID_health'
+				})
+			])
+		);
+	});
+
+	test('Unfinished variables added for each unfinished broadcast', () => {
+		const result = declareVars(SampleMemory, 1);
+
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					variableId: 'unfinished_0'
+				})
+			])
+		);
+
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					variableId: 'unfinished_short_0'
+				})
+			])
+		);
+
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					variableId: 'unfinished_state_0'
+				})
+			])
+		);
+
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					variableId: 'unfinished_health_0'
+				})
+			])
+		);
+
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					variableId: 'unfinished_concurrent_viewers_0'
 				})
 			])
 		);

--- a/src/__tests__/youtube.ts
+++ b/src/__tests__/youtube.ts
@@ -17,6 +17,7 @@ const memory: StateMemory = {
 			BoundStreamId: 'sA',
 			ScheduledStartTime: '2011-11-11T11:11:11',
 			LiveChatId: 'lcA',
+			LiveConcurrentViewers: '0',
 		},
 		bB: {
 			Id: 'bB',
@@ -26,6 +27,7 @@ const memory: StateMemory = {
 			BoundStreamId: 'sB',
 			ScheduledStartTime: '2022-22-22T22:22:22',
 			LiveChatId: 'lcB',
+			LiveConcurrentViewers: '42',
 		},
 		bC: {
 			Id: 'bC',
@@ -35,6 +37,7 @@ const memory: StateMemory = {
 			BoundStreamId: 'sB',
 			ScheduledStartTime: '2033-33-33T33:33:33',
 			LiveChatId: 'lcC',
+			LiveConcurrentViewers: '21',
 		},
 	},
 	Streams: {
@@ -60,6 +63,7 @@ const memoryUpdated: StateMemory = {
 			BoundStreamId: 'sB',
 			ScheduledStartTime: '2022-22-22T22:22:22',
 			LiveChatId: 'lcB',
+			LiveConcurrentViewers: '0',
 		},
 		bC: {
 			Id: 'bC',
@@ -69,6 +73,7 @@ const memoryUpdated: StateMemory = {
 			BoundStreamId: 'sB',
 			ScheduledStartTime: '2033-33-33T33:33:33',
 			LiveChatId: 'lcC',
+			LiveConcurrentViewers: '0',
 		},
 	},
 	Streams: {},
@@ -85,6 +90,7 @@ describe('Queries', () => {
 			expect(part).toMatch(/.*status.*/);
 			expect(part).toMatch(/.*snippet.*/);
 			expect(part).toMatch(/.*contentDetails.*/);
+			expect(part).toMatch(/.*statistics.*/);
 			expect(mine).toBe(true);
 			return Promise.resolve({
 				data: {
@@ -97,6 +103,7 @@ describe('Queries', () => {
 								monitorStream: { enableMonitorStream: true },
 								boundStreamId: 'sA',
 							},
+							statistics: { concurrentViewers: '0' },
 						},
 						{
 							id: 'bB',
@@ -106,6 +113,7 @@ describe('Queries', () => {
 								monitorStream: { enableMonitorStream: true },
 								boundStreamId: 'sB',
 							},
+							statistics: { concurrentViewers: '42' },
 						},
 						{
 							id: 'bC',
@@ -115,6 +123,7 @@ describe('Queries', () => {
 								monitorStream: { enableMonitorStream: false },
 								boundStreamId: 'sB',
 							},
+							statistics: { concurrentViewers: '21' },
 						},
 					],
 				},
@@ -127,6 +136,7 @@ describe('Queries', () => {
 	test('refresh many', async () => {
 		mock.liveBroadcasts.list.mockImplementation(({ part, id: localID }) => {
 			expect(part).toMatch(/.*status.*/);
+			expect(part).toMatch(/.*statistics.*/);
 			Object.values(memory.Broadcasts).forEach((item) => {
 				expect(localID).toMatch(new RegExp(`.*${item.Id}.*`));
 			});
@@ -136,10 +146,12 @@ describe('Queries', () => {
 						{
 							id: 'bB',
 							status: { lifeCycleStatus: 'complete' },
+							statistics: { concurrentViewers: '0' },
 						},
 						{
 							id: 'bC',
 							status: { lifeCycleStatus: 'testStarting' },
+							statistics: { concurrentViewers: '0' },
 						},
 					],
 				},
@@ -152,6 +164,7 @@ describe('Queries', () => {
 	test('refresh one - does not exist', async () => {
 		mock.liveBroadcasts.list.mockImplementation(({ part, id: localID }) => {
 			expect(part).toMatch(/.*status.*/);
+			expect(part).toMatch(/.*statistics.*/);
 			expect(localID).toBe('bA');
 			return Promise.resolve({
 				data: { items: [] },
@@ -164,6 +177,7 @@ describe('Queries', () => {
 	test('refresh one - exists', async () => {
 		mock.liveBroadcasts.list.mockImplementation(({ part, id: localID }) => {
 			expect(part).toMatch(/.*status.*/);
+			expect(part).toMatch(/.*statistics.*/);
 			expect(localID).toBe('bB');
 			return Promise.resolve({
 				data: {
@@ -171,6 +185,7 @@ describe('Queries', () => {
 						{
 							id: 'bB',
 							status: { lifeCycleStatus: 'complete' },
+							statistics: { concurrentViewers: '0' },
 						},
 					],
 				},

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -80,6 +80,9 @@ export interface Broadcast {
 
 	/** Broadcast live chat ID, e.g. KicKGFVDSXoxX3ZKLWdmd2QyNlEzY4l2RHhQZxILWVZ5OGhfNC1GZ0k */
 	LiveChatId: string;
+
+	/** Live broadcast concurrent viewers  */
+	LiveConcurrentViewers: string;
 }
 
 /**

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -222,6 +222,19 @@ export function listPresets(
 				],
 				steps: [],
 			};
+			presets[`unfinished_concurrent_viewers_number_${i}`] = {
+				type: 'button',
+				category: 'Unfinished/planned broadcasts',
+				name: `Unfinished broadcast's number of concurrent viewers #${i}`,
+				style: {
+					text: `Stream #${i}\\n$(YT:unfinished_concurrent_viewers_${i}) viewers`,
+					size: 'auto',
+					color: combineRgb(255, 255, 255),
+					bgcolor: 0,
+				},
+				feedbacks: [],
+				steps: [],
+			};
 		}
 	});
 

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -35,6 +35,7 @@ export function declareVars(memory: StateMemory, unfinishedCnt: number): Compani
 		result.push({ variableId: `unfinished_short_${i}`, name: `Unfinished/planned broadcast name shortened #${i}` });
 		result.push({ variableId: `unfinished_state_${i}`, name: `Unfinished/planned broadcast state #${i}` });
 		result.push({ variableId: `unfinished_health_${i}`, name: `Unfinished/planned broadcast's stream health #${i}` });
+		result.push({ variableId: `unfinished_concurrent_viewers_${i}`, name: `Unfinished/planned broadcast's concurrent viewers #${i}` });
 	});
 
 	return result;
@@ -168,7 +169,12 @@ export function getUnfinishedBroadcastVars(index: number, broadcast: Broadcast):
 		name: `unfinished_short_${index}`,
 		value: broadcast.Name.substr(0, 19),
 	};
-	return [contentName, contentShort];
+	const concurrentViewers: VariableContent = {
+		name: `unfinished_concurrent_viewers_${index}`,
+		value: broadcast.LiveConcurrentViewers,
+	};
+
+	return [contentName, contentShort, concurrentViewers];
 }
 
 /**
@@ -225,7 +231,12 @@ export function getUnfinishedDefaultVars(index: number): VariableContent[] {
 		name: `unfinished_state_${index}`,
 		value: 'n/a',
 	};
-	return [content, contentShort, health];
+	const concurrentViewers: VariableContent = {
+		name: `unfinished_concurrent_viewers_${index}`,
+		value: 'n/a',
+	};
+
+	return [content, contentShort, health, concurrentViewers];
 }
 
 /**


### PR DESCRIPTION
- add number of broadcast's concurrent viewers as variable
- add presets displaying the number of concurrent viewers
- unit testing suite includes tests for concurrent viewers variable and presets
- unit tests run optimization